### PR TITLE
Add commonjs build

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,13 +29,21 @@
     "README.md",
     "LICENSE"
   ],
-  "main": "dist/YALPS.js",
+  "main": "./dist/YALPS.cjs",
+  "exports": {
+    "import": "./dist/YALPS.js",
+    "require": "./dist/YALPS.cjs",
+    "default": "./dist/YALPS.js"
+  },
   "type": "module",
+  "types": "./dist/YALPS.d.ts",
   "scripts": {
     "test": "ts-node node_modules/mocha/bin/_mocha tests/Tests.ts",
     "benchmark": "ts-node tests/Benchmark.ts",
     "start": "tsc -w -p tsconfig.json",
-    "build": "tsc -p tsconfig.json",
+    "build:esm": "tsc",
+    "build:cjs": "tsc --module commonjs && mv ./dist/YALPS.js ./dist/YALPS.cjs",
+    "build": "npm run build:cjs && npm run build:esm",
     "prepare": "npm run build",
     "release": "np"
   },


### PR DESCRIPTION
Hi! :)
Thanks for your package!
I created this PR to add CJS build, as it doesn't add a lot of 'weight', but sometimes in production it's a necessity, even in 2022 (like in my case, we can't use ESM-only packages right now).

P.S. I didn't add built ".cjs" file to this PR, but can do it if needed.